### PR TITLE
chore: Adding `source: true`in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   ],
   "main": "dist/index.js",
   "module": "src/index.js",
+  "source": true,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/nilzona/path2d-polyfill.git"


### PR DESCRIPTION
Useful when using parcel as a module bundler