### PR TITLE
Bugfix: incorrect behavior with breaks between smooth curve commands

### DIFF
--- a/src/path2d-polyfill.js
+++ b/src/path2d-polyfill.js
@@ -108,21 +108,22 @@ function polyFillPath2D(window) {
     let ccw;
     const currentPoint = { x: 0, y: 0 };
 
-    // Reset control point if command is not cubic
-    if (pathType !== 'S' && pathType !== 's' && pathType !== 'C' && pathType !== 'c') {
-      cpx = null;
-      cpy = null;
-    }
-
-    if (pathType !== 'T' && pathType !== 't' && pathType !== 'Q' && pathType !== 'q') {
-      qcpx = null;
-      qcpy = null;
-    }
-
     canvas.beginPath();
     for (let i = 0; i < segments.length; ++i) {
       const s = segments[i];
       pathType = s[0];
+
+      // Reset control point if command is not cubic
+      if (pathType !== 'S' && pathType !== 's' && pathType !== 'C' && pathType !== 'c') {
+        cpx = null;
+        cpy = null;
+      }
+
+      if (pathType !== 'T' && pathType !== 't' && pathType !== 'Q' && pathType !== 'q') {
+        qcpx = null;
+        qcpy = null;
+      }
+
       switch (pathType) {
         case 'm':
           x += s[1];

--- a/test/path2d-polyfill.spec.js
+++ b/test/path2d-polyfill.spec.js
@@ -319,6 +319,13 @@ describe('Canvas path', () => {
         cMock.verify();
       });
 
+      it('S - with break between cubic command', () => {
+        cMock.expects('bezierCurveTo').withArgs(1, 2, 3, 4, 5, 6);
+        cMock.expects('bezierCurveTo').withArgs(10, 12, 10, 20, 30, 40);
+        ctx.stroke(new window.Path2D('M0 0, C1 2, 3 4, 5 6, M10 12, S10 20, 30 40'));
+        cMock.verify();
+      });
+
       it('s - with previous cubic command', () => {
         cMock.expects('bezierCurveTo').withArgs(1, 2, 3, 4, 5, 6);
         cMock.expects('bezierCurveTo').withArgs(7, 8, 15, 26, 35, 46);
@@ -329,6 +336,13 @@ describe('Canvas path', () => {
       it('s - without previous cubic command', () => {
         cMock.expects('bezierCurveTo').withArgs(1, 2, 11, 22, 31, 42);
         ctx.stroke(new window.Path2D('M1 2, s10 20 30 40'));
+        cMock.verify();
+      });
+
+      it('s - with break between cubic command', () => {
+        cMock.expects('bezierCurveTo').withArgs(1, 2, 3, 4, 5, 6);
+        cMock.expects('bezierCurveTo').withArgs(10, 12, 20, 32, 40, 52);
+        ctx.stroke(new window.Path2D('M0 0, C1 2 3 4 5 6, M10 12, s10 20 30 40'));
         cMock.verify();
       });
     });
@@ -359,6 +373,13 @@ describe('Canvas path', () => {
         cMock.verify();
       });
 
+      it('T - with break between quad command', () => {
+        cMock.expects('quadraticCurveTo').withArgs(1, 2, 3, 4);
+        cMock.expects('quadraticCurveTo').withArgs(10, 12, 10, 100);
+        ctx.stroke(new window.Path2D('M10 10, Q1 2,3 4, M10 12, T10 100'));
+        cMock.verify();
+      });
+
       it('t - with previous quad command', () => {
         cMock.expects('quadraticCurveTo').withArgs(0, 5, 10, 15);
         cMock.expects('quadraticCurveTo').withArgs(20, 25, 11, 17);
@@ -369,6 +390,13 @@ describe('Canvas path', () => {
       it('t - without previous quad command', () => {
         cMock.expects('quadraticCurveTo').withArgs(10, 100, 11, 102);
         ctx.stroke(new window.Path2D('M10 100, t1 2'));
+        cMock.verify();
+      });
+
+      it('t - with break between quad command', () => {
+        cMock.expects('quadraticCurveTo').withArgs(0, 5, 10, 15);
+        cMock.expects('quadraticCurveTo').withArgs(10, 12, 11, 14);
+        ctx.stroke(new window.Path2D('M0 0, Q0 5, 10 15, M10 12, t1 2'));
         cMock.verify();
       });
     });


### PR DESCRIPTION
## Bugfix

Currently, when a Bézier curve is followed by a non-curve command, and then by a smooth curve command (e.g. `C ... M ... S ...`), the control points of the previous curve would be used to determine the first control point of the smooth curve. This behavior is inconsistent with the SVG path specification -- when the non-curve command is issued, the control points should be reset, so the current point will be used as the first control point when the smooth command is issued.

The code implementing this behavior appeared to simply be in the wrong place. This patch moves that code into the correct place, and includes additional tests to verify the correct behavior.