### PR TITLE
Feature: support ellipse commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ import 'path2d-polyfill';
 | bezierCurveTo() | Yes |
 | quadraticCurveTo() | Yes |
 | arc()       | Yes |
-| ellipse()       | No |
+| ellipse()       | Yes |
 | rect()       | Yes |
 
 You can render SVG paths like this
@@ -50,10 +50,6 @@ You can render SVG paths like this
 ctx.fill(new Path2D('M 80 80 A 45 45 0 0 0 125 125 L 125 80 Z'));
 ctx.stroke(new Path2D('M 80 80 A 45 45 0 0 0 125 125 L 125 80 Z'));
 ```
-
-<aside class="notice">
-Unfortunately Internet Explorer does not support the `ellipse()` function so Arc commands in SVG Paths will always be based on circles and default to the first radius parameter. This can cause undesirable behaviour.
-</aside>
 
 
 ## See it in action

--- a/example/test3.js
+++ b/example/test3.js
@@ -50,3 +50,11 @@ path5.closePath();
 ctx.fillStyle = 'rgba(255, 255, 0, 0.8)';
 ctx.stroke(path5);
 ctx.fill(path5)
+
+ctx.translate(0, 50);
+var path5 = new Path2D();
+path5.ellipse(150, 120, 60, 40, 0, Math.PI, true);
+path5.closePath();
+ctx.fillStyle = 'rgba(255, 0, 0, 0.8)';
+ctx.stroke(path5);
+ctx.fill(path5)

--- a/example/test3.js
+++ b/example/test3.js
@@ -53,7 +53,7 @@ ctx.fill(path5)
 
 ctx.translate(0, 50);
 var path5 = new Path2D();
-path5.ellipse(150, 120, 60, 40, 0, Math.PI, true);
+path5.ellipse(150, 120, 60, 40, 0, 0, Math.PI, true);
 path5.closePath();
 ctx.fillStyle = 'rgba(255, 0, 0, 0.8)';
 ctx.stroke(path5);

--- a/example/test3.js
+++ b/example/test3.js
@@ -52,9 +52,9 @@ ctx.stroke(path5);
 ctx.fill(path5)
 
 ctx.translate(0, 50);
-var path5 = new Path2D();
-path5.ellipse(150, 120, 60, 40, 0, 0, Math.PI, true);
-path5.closePath();
+var path6 = new Path2D();
+path6.ellipse(150, 120, 60, 40, 0, 0, Math.PI, true);
+path6.closePath();
 ctx.fillStyle = 'rgba(255, 0, 0, 0.8)';
-ctx.stroke(path5);
-ctx.fill(path5)
+ctx.stroke(path6);
+ctx.fill(path6)

--- a/example/test4.js
+++ b/example/test4.js
@@ -1,0 +1,33 @@
+/* eslint-disable */
+var canvas = document.getElementById('can4');
+var ctx = canvas.getContext('2d')
+
+ctx.translate(50,50);
+
+ctx.strokeStyle = 'red';
+var path1 = new Path2D('M 10 90 l 40 -40')
+ctx.stroke(path1);
+
+ctx.strokeStyle = 'black';
+var path1 = new Path2D('M 10 90 a 30 50 -20 1 0 40 -40')
+ctx.stroke(path1);
+
+ctx.strokeStyle = 'black';
+var path1 = new Path2D('M 10 90 a 40 60 20 1 1 40 -40')
+ctx.stroke(path1);
+
+ctx.strokeStyle = 'blue';
+var path1 = new Path2D('M 10 90 a 30 50 -20 0 1 40 -40')
+ctx.stroke(path1);
+
+ctx.strokeStyle = 'blue';
+var path1 = new Path2D('M 10 90 a 40 60 20 0 0 40 -40')
+ctx.stroke(path1);
+
+ctx.strokeStyle = 'black';
+var path1 = new Path2D(`M0,300 l 30,-15
+a15,15 -30 0,1 30,-15 l 30,-15
+a15,30 -30 0,1 30,-15 l 30,-15
+a15,45 -30 0,1 30,-15 l 30,-15
+a15,60 -30 0,1 30,-15 l 30,-15`)
+ctx.stroke(path1);

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
       #ex1 { position: absolute; top: 50px; left: 50px }
       #ex2 { position: absolute; top: 50px; left: 600px }
       #ex3 { position: absolute; top: 600px; left: 50px }
+      #ex4 { position: absolute; top: 600px; left: 600px }
     </style>
   </head>
   <body>
@@ -25,10 +26,15 @@
           <div>Use Path2D methods</div>
           <canvas id="can3" width="500" height="500"></canvas>
         </div>
+      <div id="ex4">
+        <div>Ellipse example</div>
+        <canvas id="can4" width="500" height="500"></canvas>
+      </div>
     </div>
     <script lang="javascript" src='src/index.js'></script>
     <script lang="javascript" src="example/test.js"></script>
     <script lang="javascript" src="example/test2.js"></script>
     <script lang="javascript" src="example/test3.js"></script>
+    <script lang="javascript" src="example/test4.js"></script>
   </body>
 </html>

--- a/src/path2d-polyfill.js
+++ b/src/path2d-polyfill.js
@@ -27,6 +27,11 @@ function translatePoint(point, dx, dy) {
   point.y += dy;
 }
 
+function scalePoint(point, s) {
+  point.x *= s;
+  point.y *= s;
+}
+
 function polyFillPath2D(window) {
   if (typeof window === 'undefined' || !window.CanvasRenderingContext2D) {
     return;
@@ -67,6 +72,9 @@ function polyFillPath2D(window) {
     arcTo(x1, y1, x2, y2, r) {
       this.segments.push(['AT', x1, y1, x2, y2, r]);
     }
+    ellipse(x, y, rx, ry, start, end, ccw) {
+      this.segments.push(['E', x, y, rx, ry, start, end, !!ccw]);
+    }
     closePath() {
       this.segments.push(['Z']);
     }
@@ -90,13 +98,17 @@ function polyFillPath2D(window) {
     let largeArcFlag;
     let sweepFlag;
     let endPoint;
+    let midPoint;
     let angle;
+    let lambda;
+    let t1;
+    let t2;
     let x;
     let x1;
     let y;
     let y1;
     let r;
-    let b;
+    let r1;
     let w;
     let h;
     let pathType;
@@ -170,45 +182,65 @@ function polyFillPath2D(window) {
             y = s[7];
           }
 
-          r = s[1];
-          // s[2] = 2nd radius in ellipse, ignore
-          // s[3] = rotation of ellipse, ignore
-          largeArcFlag = s[4];
-          sweepFlag = s[5];
+          r = s[1]; // rx
+          r1 = s[2]; // ry
+          angle = (s[3] * Math.PI) / 180;
+          largeArcFlag = !!s[4];
+          sweepFlag = !!s[5];
           endPoint = { x, y };
-          // translate all points so that currentPoint is origin
-          translatePoint(endPoint, -currentPoint.x, -currentPoint.y);
 
-          // angle to destination
-          angle = Math.atan2(endPoint.y, endPoint.x);
+          // https://www.w3.org/TR/SVG/implnote.html#ArcImplementationNotes
 
-          // rotate points so that angle is 0
-          rotatePoint(endPoint, -angle);
+          midPoint = {
+            x: (currentPoint.x - endPoint.x) / 2,
+            y: (currentPoint.y - endPoint.y) / 2,
+          };
+          rotatePoint(midPoint, -angle);
 
-          b = endPoint.x / 2;
-          // var sweepAngle = Math.asin(b / r);
-
-          centerPoint = { x: 0, y: 0 };
-          centerPoint.x = endPoint.x / 2;
-          if ((sweepFlag && !largeArcFlag) || (!sweepFlag && largeArcFlag)) {
-            centerPoint.y = Math.sqrt((r * r) - (b * b));
-          } else {
-            centerPoint.y = -Math.sqrt((r * r) - (b * b));
+          // radius correction
+          lambda = ((midPoint.x * midPoint.x) / (r * r))
+                 + ((midPoint.y * midPoint.y) / (r1 * r1));
+          if (lambda > 1) {
+            lambda = Math.sqrt(lambda);
+            r *= lambda;
+            r1 *= lambda;
           }
-          startAngle = Math.atan2(-centerPoint.y, -centerPoint.x);
-          endAngle = Math.atan2(endPoint.y - centerPoint.y, endPoint.x - centerPoint.x);
 
-          // rotate back
-          startAngle += angle;
-          endAngle += angle;
-          rotatePoint(endPoint, angle);
+          centerPoint = {
+            x: (r * midPoint.y) / r1,
+            y: -(r1 * midPoint.x) / r,
+          };
+          t1 = r * r * r1 * r1;
+          t2 = (r * r * midPoint.y * midPoint.y)
+             + (r1 * r1 * midPoint.x * midPoint.x);
+          if (sweepFlag !== largeArcFlag) {
+            scalePoint(centerPoint, Math.sqrt((t1 - t2) / t2) || 0);
+          } else {
+            scalePoint(centerPoint, -Math.sqrt((t1 - t2) / t2) || 0);
+          }
+
+          startAngle = Math.atan2(
+            (midPoint.y - centerPoint.y) / r1,
+            (midPoint.x - centerPoint.x) / r,
+          );
+          endAngle = Math.atan2(
+            -(midPoint.y + centerPoint.y) / r1,
+            -(midPoint.x + centerPoint.x) / r,
+          );
+
           rotatePoint(centerPoint, angle);
+          translatePoint(
+            centerPoint,
+            (endPoint.x + currentPoint.x) / 2,
+            (endPoint.y + currentPoint.y) / 2,
+          );
 
-          // translate points
-          translatePoint(endPoint, currentPoint.x, currentPoint.y);
-          translatePoint(centerPoint, currentPoint.x, currentPoint.y);
-
-          canvas.arc(centerPoint.x, centerPoint.y, r, startAngle, endAngle, !sweepFlag);
+          canvas.save();
+          canvas.translate(centerPoint.x, centerPoint.y);
+          canvas.rotate(angle);
+          canvas.scale(r, r1);
+          canvas.arc(0, 0, 1, startAngle, endAngle, !sweepFlag);
+          canvas.restore();
           break;
         case 'C':
           cpx = s[3]; // Last control point
@@ -325,6 +357,20 @@ function polyFillPath2D(window) {
           y = s[4];
           r = s[5];
           canvas.arcTo(x1, y1, x, y, r);
+          break;
+        case 'E': // ellipse
+          x = s[1];
+          y = s[2];
+          r = s[3];
+          r1 = s[4];
+          startAngle = s[5];
+          endAngle = s[6];
+          ccw = s[7];
+          canvas.save();
+          canvas.translate(x, y);
+          canvas.scale(r, r1);
+          canvas.arc(0, 0, 1, startAngle, endAngle, ccw);
+          canvas.restore();
           break;
         case 'R': // rect
           x = s[1];

--- a/src/path2d-polyfill.js
+++ b/src/path2d-polyfill.js
@@ -72,8 +72,8 @@ function polyFillPath2D(window) {
     arcTo(x1, y1, x2, y2, r) {
       this.segments.push(['AT', x1, y1, x2, y2, r]);
     }
-    ellipse(x, y, rx, ry, start, end, ccw) {
-      this.segments.push(['E', x, y, rx, ry, start, end, !!ccw]);
+    ellipse(x, y, rx, ry, angle, start, end, ccw) {
+      this.segments.push(['E', x, y, rx, ry, angle, start, end, !!ccw]);
     }
     closePath() {
       this.segments.push(['Z']);
@@ -363,11 +363,13 @@ function polyFillPath2D(window) {
           y = s[2];
           r = s[3];
           r1 = s[4];
-          startAngle = s[5];
-          endAngle = s[6];
-          ccw = s[7];
+          angle = s[5];
+          startAngle = s[6];
+          endAngle = s[7];
+          ccw = s[8];
           canvas.save();
           canvas.translate(x, y);
+          canvas.rotate(angle);
           canvas.scale(r, r1);
           canvas.arc(0, 0, 1, startAngle, endAngle, ccw);
           canvas.restore();

--- a/test/path2d-polyfill.spec.js
+++ b/test/path2d-polyfill.spec.js
@@ -19,6 +19,11 @@ describe('Canvas path', () => {
       bezierCurveTo() {},
       quadraticCurveTo() {},
       rect() {},
+      save() {},
+      translate() {},
+      rotate() {},
+      scale() {},
+      restore() {},
       strokeStyle: null,
       lineWidth: null,
     };
@@ -195,6 +200,15 @@ describe('Canvas path', () => {
         ctx.stroke(p);
         cMock.verify();
       });
+      it('ellipse', () => {
+        cMock.expects('translate').once().withArgs(100, 150);
+        cMock.expects('scale').once().withArgs(20, 40);
+        cMock.expects('arc').once().withArgs(0, 0, 1, 0, Math.PI, true);
+        const p = new window.Path2D();
+        p.ellipse(100, 150, 20, 40, 0, Math.PI, true);
+        ctx.stroke(p);
+        cMock.verify();
+      });
       it('rect', () => {
         cMock.expects('rect').once().withArgs(20, 20, 30, 30);
         const p = new window.Path2D();
@@ -265,7 +279,9 @@ describe('Canvas path', () => {
     describe('arc', () => {
       it('A', () => {
         cMock.expects('moveTo').once().withArgs(80, 80);
-        cMock.expects('arc').once().withArgs(125, 80, 45, Math.PI, Math.PI / 2, true);
+        cMock.expects('translate').once().withArgs(125, 80);
+        cMock.expects('scale').once().withArgs(45, 45);
+        cMock.expects('arc').once().withArgs(0, 0, 1, Math.PI, Math.PI / 2, true);
         cMock.expects('lineTo').once().withArgs(125, 80);
         cMock.expects('closePath').once();
         ctx.stroke(new window.Path2D('M80 80A 45 45 0 0 0 125 125L 125 80 Z'));
@@ -273,8 +289,18 @@ describe('Canvas path', () => {
       });
 
       it('a - with sweep flag and large flag arc', () => {
-        cMock.expects('arc').once().withArgs(275, 230, 45, Math.PI, Math.PI / 2, false);
+        cMock.expects('translate').once().withArgs(275, 230);
+        cMock.expects('scale').once().withArgs(45, 45);
+        cMock.expects('arc').once().withArgs(0, 0, 1, Math.PI, Math.PI / 2, false);
         ctx.stroke(new window.Path2D('M230 230a 45 45 0 1 1 45 45L 275 230 Z'));
+        cMock.verify();
+      });
+
+      it('a - elliptical', () => {
+        cMock.expects('translate').once().withArgs(250, 230);
+        cMock.expects('scale').once().withArgs(20, 40);
+        cMock.expects('arc').once().withArgs(0, 0, 1, Math.PI, 0, false);
+        ctx.stroke(new window.Path2D('M230 230a 20 40 0 1 1 40 0L 275 230 Z'));
         cMock.verify();
       });
     });

--- a/test/path2d-polyfill.spec.js
+++ b/test/path2d-polyfill.spec.js
@@ -299,7 +299,7 @@ describe('Canvas path', () => {
       it('a - elliptical', () => {
         cMock.expects('translate').once().withArgs(250, 230);
         cMock.expects('scale').once().withArgs(20, 40);
-        cMock.expects('arc').once().withArgs(0, 0, 1, Math.PI, 0, false);
+        cMock.expects('arc').once().withArgs(0, 0, 1, Math.PI, -0, false);
         ctx.stroke(new window.Path2D('M230 230a 20 40 0 1 1 40 0L 275 230 Z'));
         cMock.verify();
       });

--- a/test/path2d-polyfill.spec.js
+++ b/test/path2d-polyfill.spec.js
@@ -205,7 +205,7 @@ describe('Canvas path', () => {
         cMock.expects('scale').once().withArgs(20, 40);
         cMock.expects('arc').once().withArgs(0, 0, 1, 0, Math.PI, true);
         const p = new window.Path2D();
-        p.ellipse(100, 150, 20, 40, 0, Math.PI, true);
+        p.ellipse(100, 150, 20, 40, 0, 0, Math.PI, true);
         ctx.stroke(p);
         cMock.verify();
       });


### PR DESCRIPTION
## Feature

Currently, ellipse commands aren't supported due to lack of support for the `ellipse()` canvas method in IE. However, ellipses can also be drawn by transforming the canvas and using the `arc()` command, which is widely supported.

This patch adds support for `Path2D.ellipse()`, as well as full support for SVG arc commands (`a` and `A`) including those with different x and y radii and rotation.

The code to convert from endpoint to center parameterization was based off of the W3 SVG implementation notes which can be found at https://www.w3.org/TR/SVG/implnote.html#ArcImplementationNotes .

Also includes automated tests and an additional visual example.