### PR TITLE
fix: move current position when a path is closed

### DIFF
--- a/example/test5.js
+++ b/example/test5.js
@@ -1,0 +1,11 @@
+/* eslint-disable */
+var canvas = document.getElementById('can5');
+var ctx = canvas.getContext('2d')
+
+var path = new Path2D('M20,20h100v100Zm120,0h100v100Z');
+
+ctx.strokeStyle = '#666';
+ctx.fillStyle = '#DDD';
+
+ctx.fill(path);
+ctx.stroke(path);

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
       #ex1 { position: absolute; top: 50px; left: 50px }
       #ex2 { position: absolute; top: 50px; left: 600px }
       #ex3 { position: absolute; top: 600px; left: 50px }
+      #ex5 { position: absolute; top: 1150px; left: 50px }
     </style>
   </head>
   <body>
@@ -22,13 +23,18 @@
         <canvas id="can2" width="500" height="500"></canvas>
       </div>
       <div id="ex3">
-          <div>Use Path2D methods</div>
-          <canvas id="can3" width="500" height="500"></canvas>
-        </div>
+        <div>Use Path2D methods</div>
+        <canvas id="can3" width="500" height="500"></canvas>
+      </div>
+      <div id="ex5">
+        <div>Close example</div>
+        <canvas id="can5" width="500" height="500"></canvas>
+      </div>
     </div>
     <script lang="javascript" src='src/index.js'></script>
     <script lang="javascript" src="example/test.js"></script>
     <script lang="javascript" src="example/test2.js"></script>
     <script lang="javascript" src="example/test3.js"></script>
+    <script lang="javascript" src="example/test5.js"></script>
   </body>
 </html>

--- a/src/path2d-polyfill.js
+++ b/src/path2d-polyfill.js
@@ -106,6 +106,7 @@ function polyFillPath2D(window) {
     let qcpx;
     let qcpy;
     let ccw;
+    let startPoint = { x: 0, y: 0 };
     const currentPoint = { x: 0, y: 0 };
 
     // Reset control point if command is not cubic
@@ -125,13 +126,19 @@ function polyFillPath2D(window) {
       pathType = s[0];
       switch (pathType) {
         case 'm':
-          x += s[1];
-          y += s[2];
-          canvas.moveTo(x, y);
-          break;
         case 'M':
-          x = s[1];
-          y = s[2];
+          if (pathType === 'm') {
+            x += s[1];
+            y += s[2];
+          } else {
+            x = s[1];
+            y = s[2];
+          }
+
+          if (pathType === 'M' || !startPoint) {
+            startPoint = { x, y };
+          }
+
           canvas.moveTo(x, y);
           break;
         case 'l':
@@ -307,6 +314,9 @@ function polyFillPath2D(window) {
           break;
         case 'z':
         case 'Z':
+          x = startPoint.x;
+          y = startPoint.y;
+          startPoint = undefined;
           canvas.closePath();
           break;
         case 'AC': // arc
@@ -331,6 +341,7 @@ function polyFillPath2D(window) {
           y = s[2];
           w = s[3];
           h = s[4];
+          startPoint = { x, y };
           canvas.rect(x, y, w, h);
           break;
         default:


### PR DESCRIPTION
The current position does not correctly move to the start point when a path is closed. This issue is visible only when a path contains multiple closes. The included example shows this perfectly.

```javascript
new Path2D('M20,20h100v100Zm120,0h100v100Z')
```

Before:
![before](https://user-images.githubusercontent.com/1223086/56042714-fd8f6e80-5d3b-11e9-8b59-52bdb95c45e7.png)

After:
![after](https://user-images.githubusercontent.com/1223086/56042723-02ecb900-5d3c-11e9-9ce6-3f04d4ca0a00.png)

***Please note that the example uses 5 as its ID to avoid collision with #7.***