### PR TITLE
fix: CanvasRenderingContext2D type compatible with non-polyfilled

### DIFF
--- a/.changeset/happy-ladybugs-camp.md
+++ b/.changeset/happy-ladybugs-camp.md
@@ -1,0 +1,5 @@
+---
+"path2d": patch
+---
+
+Make types compatible with node-canvas

--- a/packages/path2d-polyfill/vite.config.ts
+++ b/packages/path2d-polyfill/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
       plugins: [
         babel({
           presets: ["@babel/preset-env"],
+          babelHelpers: "bundled",
         }),
       ],
     },

--- a/packages/path2d/README.md
+++ b/packages/path2d/README.md
@@ -33,8 +33,7 @@ const { createCanvas, CanvasRenderingContext2D } = require("canvas");
 const { applyPath2DToCanvasRenderingContext, Path2D } = require("path2d");
 
 applyPath2DToCanvasRenderingContext(CanvasRenderingContext2D);
-global.CanvasRenderingContext2D = CanvasRenderingContext2D;
-// Path2D has now been added to global object
+// Path2D features has now been added to CanvasRenderingContext2D
 
 const canvas = createCanvas(200, 200);
 const ctx = canvas.getContext("2d");

--- a/packages/path2d/package.json
+++ b/packages/path2d/package.json
@@ -26,6 +26,7 @@
     }
   },
   "main": "dist/index.cjs",
+  "module": "./dist/index.js",
   "files": [
     "dist"
   ],

--- a/packages/path2d/src/apply.ts
+++ b/packages/path2d/src/apply.ts
@@ -1,6 +1,13 @@
 import { Path2D, buildPath } from "./path2d.js";
 import { roundRect } from "./round-rect.js";
-import type { CanvasFillRule, ICanvasRenderingContext2D, IPath2D, IPrototype, PartialBy } from "./types.js";
+import type {
+  CanvasFillRule,
+  ICanvasRenderingContext2D,
+  ICanvasRenderingContext2DWithoutPath2D,
+  IPath2D,
+  IPrototype,
+  PartialBy,
+} from "./types.js";
 
 type FillFn = (fillRule?: CanvasFillRule) => void;
 type StrokeFn = () => void;
@@ -10,7 +17,9 @@ type IsPointInPathFn = (x: number, y: number, fillRule?: CanvasFillRule) => bool
  * Adds Path2D capabilities to CanvasRenderingContext2D stroke, fill and isPointInPath
  * @param global - window like object containing a CanvasRenderingContext2D constructor
  */
-export function applyPath2DToCanvasRenderingContext(CanvasRenderingContext2D?: IPrototype<ICanvasRenderingContext2D>) {
+export function applyPath2DToCanvasRenderingContext(
+  CanvasRenderingContext2D?: IPrototype<ICanvasRenderingContext2DWithoutPath2D>,
+) {
   if (!CanvasRenderingContext2D) return;
 
   /* eslint-disable @typescript-eslint/unbound-method */
@@ -24,7 +33,7 @@ export function applyPath2DToCanvasRenderingContext(CanvasRenderingContext2D?: I
     if (args[0] instanceof Path2D) {
       const path = args[0];
       const fillRule = (args[1] as CanvasFillRule) || "nonzero";
-      buildPath(this, path.commands);
+      buildPath(this as ICanvasRenderingContext2D, path.commands);
       return cFill.apply(this, [fillRule]);
     }
     const fillRule = (args[0] as CanvasFillRule) || "nonzero";
@@ -33,7 +42,7 @@ export function applyPath2DToCanvasRenderingContext(CanvasRenderingContext2D?: I
 
   CanvasRenderingContext2D.prototype.stroke = function stroke(path?: Path2D) {
     if (path) {
-      buildPath(this, path.commands);
+      buildPath(this as ICanvasRenderingContext2D, path.commands);
     }
     cStroke.apply(this);
   };
@@ -45,7 +54,7 @@ export function applyPath2DToCanvasRenderingContext(CanvasRenderingContext2D?: I
       const x = args[1] as number;
       const y = args[2] as number;
       const fillRule = (args[3] as CanvasFillRule) || "nonzero";
-      buildPath(this, path.commands);
+      buildPath(this as ICanvasRenderingContext2D, path.commands);
       return cIsPointInPath.apply(this, [x, y, fillRule]);
     }
     return cIsPointInPath.apply(this, args as [x: number, y: number, fillRule: CanvasFillRule]);

--- a/packages/path2d/src/types.ts
+++ b/packages/path2d/src/types.ts
@@ -102,9 +102,34 @@ export interface ICanvasRenderingContext2D {
   roundRect(x: number, y: number, width: number, height: number, radii: number | number[]): void;
 }
 
+export interface ICanvasRenderingContext2DWithoutPath2D {
+  beginPath(): void;
+  save(): void;
+  translate(x: number, y: number): void;
+  rotate(angle: number): void;
+  scale(x: number, y: number): void;
+  restore(): void;
+  moveTo(x: number, y: number): void;
+  lineTo(x: number, y: number): void;
+  arc(x: number, y: number, r: number, start: number, end: number, ccw: boolean): void;
+  arcTo(x1: number, y1: number, x2: number, y2: number, r: number): void;
+  ellipse(x: number, y: number, rx: number, ry: number, angle: number, start: number, end: number, ccw: boolean): void;
+  closePath(): void;
+  bezierCurveTo(cp1x: number, cp1y: number, cp2x: number, cp2y: number, x: number, y: number): void;
+  quadraticCurveTo(cpx: number, cpy: number, x: number, y: number): void;
+  rect(x: number, y: number, width: number, height: number): void;
+  isPointInPath(x: number, y: number, fillRule?: CanvasFillRule): boolean;
+  // isPointInPath(path: Path2D, x: number, y: number, fillRule?: CanvasFillRule): boolean;
+  fill(fillRule?: CanvasFillRule): void;
+  // fill(path: Path2D, fillRule?: CanvasFillRule): void;
+  stroke(): void;
+  // stroke(path: Path2D): void;
+  roundRect(x: number, y: number, width: number, height: number, radii: number | number[]): void;
+}
+
 export type IPrototype<T> = {
   prototype: T;
   new (): T;
 };
-
 export type PartialBy<T, K extends keyof T> = Omit<T, K> & { [P in K]?: T[P] };
+export type CanvasRenderingContext2DProt = IPrototype<ICanvasRenderingContext2D>;

--- a/turbo.json
+++ b/turbo.json
@@ -1,25 +1,13 @@
 {
   "pipeline": {
     "build": {
-      "outputs": []
+      "dependsOn": ["^build"]
     },
-    "dev": {
-      "outputs": []
-    },
-    "lint": {
-      "outputs": []
-    },
-    "check-types": {
-      "outputs": []
-    },
-    "test": {
-      "outputs": []
-    },
-    "format:check": {
-      "outputs": []
-    },
-    "format:write": {
-      "outputs": []
-    }
+    "dev": {},
+    "lint": {},
+    "check-types": {},
+    "test": {},
+    "format:check": {},
+    "format:write": {}
   }
 }


### PR DESCRIPTION
- Fixes example in documentation
- Fix incompatible types with `node-canvas`

resolves #56 