### PR TITLE
feat: polyfill `clip()`

### DIFF
--- a/packages/path2d-polyfill/index.html
+++ b/packages/path2d-polyfill/index.html
@@ -64,6 +64,10 @@
         <div>Rounded rect example</div>
         <canvas id="rounded-rect-canvas" width="500" height="500"></canvas>
       </div>
+      <div class="square">
+        <div>Clip function example</div>
+        <canvas id="clip-canvas" width="500" height="500"></canvas>
+      </div>
     </div>
     <script type="module" src="/src/index.ts"></script>
     <script type="module" src="/test/arc.js"></script>
@@ -73,5 +77,6 @@
     <script type="module" src="/test/close.js"></script>
     <script type="module" src="/test/point-inside.js"></script>
     <script type="module" src="/test/rounded-rect.js"></script>
+    <script type="module" src="/test/clip.js"></script>
   </body>
 </html>

--- a/packages/path2d-polyfill/src/__test__/test-types.ts
+++ b/packages/path2d-polyfill/src/__test__/test-types.ts
@@ -8,6 +8,7 @@ export class CanvasRenderingContext2DForTest implements ICanvasRenderingContext2
     this.strokeStyle = null;
     this.lineWidth = null;
   }
+  clip(a?: CanvasFillRule | Path2D, b?: CanvasFillRule) {}
   fill(a?: CanvasFillRule | Path2D, b?: CanvasFillRule) {}
   stroke(a?: CanvasFillRule | Path2D) {}
   isPointInPath(a: number | Path2D, b: number, c?: number | CanvasFillRule, d?: number | CanvasFillRule) {

--- a/packages/path2d-polyfill/test/clip.js
+++ b/packages/path2d-polyfill/test/clip.js
@@ -1,0 +1,15 @@
+(function run() {
+  const canvas = document.getElementById("clip-canvas");
+  const ctx = canvas?.getContext("2d");
+  if (ctx) {
+    // Create clipping path
+    const region = new Path2D();
+    region.rect(80, 10, 20, 130);
+    region.rect(40, 50, 100, 50);
+    ctx.clip(region, "evenodd");
+
+    // Draw stuff that gets clipped
+    ctx.fillStyle = "blue";
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+  }
+})();

--- a/packages/path2d/src/__test__/test-types.ts
+++ b/packages/path2d/src/__test__/test-types.ts
@@ -10,6 +10,7 @@ export class CanvasRenderingContext2DForTest implements ICanvasRenderingContext2
     this.strokeStyle = null;
     this.lineWidth = null;
   }
+  clip(a?: CanvasFillRule | Path2D, b?: CanvasFillRule) {}
   fill(a?: CanvasFillRule | Path2D, b?: CanvasFillRule) {}
   stroke(a?: CanvasFillRule | Path2D) {}
   isPointInPath(a: number | Path2D, b: number, c?: number | CanvasFillRule, d?: number | CanvasFillRule) {
@@ -40,6 +41,7 @@ export class CanvasRenderingContext2DForTestWithoutRoundRect {
     this.strokeStyle = null;
     this.lineWidth = null;
   }
+  clip(a?: CanvasFillRule | Path2D, b?: CanvasFillRule) {}
   fill(a?: CanvasFillRule | Path2D, b?: CanvasFillRule) {}
   stroke(a?: CanvasFillRule | Path2D) {}
   isPointInPath(a: number | Path2D, b: number, c?: number | CanvasFillRule, d?: number | CanvasFillRule) {

--- a/packages/path2d/src/apply.ts
+++ b/packages/path2d/src/apply.ts
@@ -24,10 +24,22 @@ export function applyPath2DToCanvasRenderingContext(
 
   /* eslint-disable @typescript-eslint/unbound-method */
   // setting unbound functions here. Make sure this is set in function call later
+  const cClip: FillFn = CanvasRenderingContext2D.prototype.clip;
   const cFill: FillFn = CanvasRenderingContext2D.prototype.fill;
   const cStroke: StrokeFn = CanvasRenderingContext2D.prototype.stroke;
   const cIsPointInPath: IsPointInPathFn = CanvasRenderingContext2D.prototype.isPointInPath;
   /* eslint-enable @typescript-eslint/unbound-method */
+
+  CanvasRenderingContext2D.prototype.clip = function clip(...args: unknown[]) {
+    if (args[0] instanceof Path2D) {
+      const path = args[0];
+      const fillRule = (args[1] as CanvasFillRule) || "nonzero";
+      buildPath(this as ICanvasRenderingContext2D, path.commands);
+      return cClip.apply(this, [fillRule]);
+    }
+    const fillRule = (args[0] as CanvasFillRule) || "nonzero";
+    return cClip.apply(this, [fillRule]);
+  };
 
   CanvasRenderingContext2D.prototype.fill = function fill(...args: unknown[]) {
     if (args[0] instanceof Path2D) {

--- a/packages/path2d/src/types.ts
+++ b/packages/path2d/src/types.ts
@@ -95,6 +95,8 @@ export interface ICanvasRenderingContext2D {
   rect(x: number, y: number, width: number, height: number): void;
   isPointInPath(x: number, y: number, fillRule?: CanvasFillRule): boolean;
   isPointInPath(path: Path2D, x: number, y: number, fillRule?: CanvasFillRule): boolean;
+  clip(fillRule?: CanvasFillRule): void;
+  clip(path: Path2D, fillRule?: CanvasFillRule): void;
   fill(fillRule?: CanvasFillRule): void;
   fill(path: Path2D, fillRule?: CanvasFillRule): void;
   stroke(): void;
@@ -120,6 +122,8 @@ export interface ICanvasRenderingContext2DWithoutPath2D {
   rect(x: number, y: number, width: number, height: number): void;
   isPointInPath(x: number, y: number, fillRule?: CanvasFillRule): boolean;
   // isPointInPath(path: Path2D, x: number, y: number, fillRule?: CanvasFillRule): boolean;
+  clip(fillRule?: CanvasFillRule): void;
+  // clip(path: Path2D, fillRule?: CanvasFillRule): void;
   fill(fillRule?: CanvasFillRule): void;
   // fill(path: Path2D, fillRule?: CanvasFillRule): void;
   stroke(): void;


### PR DESCRIPTION
I've noticed that this polyfill is missing the `clip()` method, which has the same signature and behaviour as `fill()` which makes it really easy to add.

https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/clip#syntax

Used and tested on our tests in `ag-charts`.
Wasn't sure if this is a feature or a bug fix :)