### PR TITLE
fix: rounded rect bottom-right corner

### DIFF
--- a/.changeset/healthy-planes-marry.md
+++ b/.changeset/healthy-planes-marry.md
@@ -1,0 +1,5 @@
+---
+"path2d": patch
+---
+
+Fix rounded rect bottom-right corner

--- a/packages/path2d/src/__test__/round-rect.spec.ts
+++ b/packages/path2d/src/__test__/round-rect.spec.ts
@@ -62,6 +62,7 @@ describe("roundRect", () => {
     ctx.stroke(p);
     expect(ctx.moveTo).not.toHaveBeenCalled();
     expect(ctx.arcTo).not.toHaveBeenCalled();
+    expect(ctx.closePath).not.toHaveBeenCalled();
   });
 
   it("with one radius", () => {
@@ -73,7 +74,7 @@ describe("roundRect", () => {
     expect(ctx.arcTo).toHaveBeenNthCalledWith(2, 10, 0, 10, 1, 1);
     expect(ctx.arcTo).toHaveBeenNthCalledWith(3, 10, 10, 9, 10, 1);
     expect(ctx.arcTo).toHaveBeenNthCalledWith(4, 0, 10, 0, 9, 1);
-    expect(ctx.moveTo).toHaveBeenNthCalledWith(2, 0, 0);
+    expect(ctx.closePath).toHaveBeenCalled();
   });
 
   it("with one radius - as array", () => {
@@ -85,7 +86,7 @@ describe("roundRect", () => {
     expect(ctx.arcTo).toHaveBeenNthCalledWith(2, 10, 0, 10, 1, 1);
     expect(ctx.arcTo).toHaveBeenNthCalledWith(3, 10, 10, 9, 10, 1);
     expect(ctx.arcTo).toHaveBeenNthCalledWith(4, 0, 10, 0, 9, 1);
-    expect(ctx.moveTo).toHaveBeenNthCalledWith(2, 0, 0);
+    expect(ctx.closePath).toHaveBeenCalled();
   });
 
   it("with two radiuses", () => {
@@ -97,7 +98,7 @@ describe("roundRect", () => {
     expect(ctx.arcTo).toHaveBeenNthCalledWith(2, 10, 0, 10, 2, 2);
     expect(ctx.arcTo).toHaveBeenNthCalledWith(3, 10, 10, 9, 10, 1);
     expect(ctx.arcTo).toHaveBeenNthCalledWith(4, 0, 10, 0, 8, 2);
-    expect(ctx.moveTo).toHaveBeenNthCalledWith(2, 0, 0);
+    expect(ctx.closePath).toHaveBeenCalled();
   });
 
   it("with three radiuses", () => {
@@ -109,7 +110,7 @@ describe("roundRect", () => {
     expect(ctx.arcTo).toHaveBeenNthCalledWith(2, 10, 0, 10, 2, 2);
     expect(ctx.arcTo).toHaveBeenNthCalledWith(3, 10, 10, 7, 10, 3);
     expect(ctx.arcTo).toHaveBeenNthCalledWith(4, 0, 10, 0, 8, 2);
-    expect(ctx.moveTo).toHaveBeenNthCalledWith(2, 0, 0);
+    expect(ctx.closePath).toHaveBeenCalled();
   });
 
   it("with four radiuses", () => {
@@ -121,6 +122,6 @@ describe("roundRect", () => {
     expect(ctx.arcTo).toHaveBeenNthCalledWith(2, 10, 0, 10, 2, 2);
     expect(ctx.arcTo).toHaveBeenNthCalledWith(3, 10, 10, 7, 10, 3);
     expect(ctx.arcTo).toHaveBeenNthCalledWith(4, 0, 10, 0, 6, 4);
-    expect(ctx.moveTo).toHaveBeenNthCalledWith(2, 0, 0);
+    expect(ctx.closePath).toHaveBeenCalled();
   });
 });

--- a/packages/path2d/src/round-rect.ts
+++ b/packages/path2d/src/round-rect.ts
@@ -66,6 +66,5 @@ export function roundRect(
   this.arcTo(x + width, y, x + width, y + tr, tr);
   this.arcTo(x + width, y + height, x + width - br, y + height, br);
   this.arcTo(x, y + height, x, y + height - bl, bl);
-  // and move to rects control point for further path drawing
-  this.moveTo(x, y);
+  this.closePath();
 }


### PR DESCRIPTION
roundRect() gets the bottom-right corner wrong, when there's no radius. See example at https://playcode.io/2056390

```
    roundRect.call(ctx, 10, 10, 60, 60, [15, 15, 15, 0]);
    ctx.lineWidth = 10
    ctx.stroke()
```

Upstream: 

![Screenshot from 2024-10-23 22-34-28](https://github.com/user-attachments/assets/0afa6037-eb83-4064-aaac-c9fba85f42f8)

Fixed with `closePath()`: 
![Screenshot from 2024-10-23 22-34-43](https://github.com/user-attachments/assets/e9b9cfdc-939d-4393-bbd8-47995f518d6e)

